### PR TITLE
Update chat.go

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -86,7 +86,7 @@ type ChatCompletionRequestBody struct {
 	Functions json.Marshaler `json:"functions,omitempty"`
 
 	// FunctionCall: You ain't need it. Default is "auto".
-	FunctionCall string `json:"function_call,omitempty"`
+	FunctionCall json.RawMessage `json:"function_call,omitempty"`
 }
 
 type Functions []Function


### PR DESCRIPTION
'$.function_call' is invalid. Please check the API reference: https://platform.openai.com/docs/api-reference.